### PR TITLE
Add RemoteUploadHost console project with config validation

### DIFF
--- a/src/ArchiveNow.sln
+++ b/src/ArchiveNow.sln
@@ -55,7 +55,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArchiveNow.Configuration.Storages", "ArchiveNow.Configuration.Storages\ArchiveNow.Configuration.Storages.csproj", "{EFC44E4D-FBF0-4F15-AE17-D413A249FF8B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArchiveNow.Providers.Listing", "ArchiveNow.Providers.Listing\ArchiveNow.Providers.Listing.csproj", "{9DE82421-3B3F-4B89-8585-7E87F615B1D6}"
+
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RemoteUploadHost", "RemoteUploadHost\RemoteUploadHost.csproj", "{5CF6FE83-5238-46F1-8102-FCC58BE19F79}"
 EndProject
+
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -230,6 +233,16 @@ Global
 		{9DE82421-3B3F-4B89-8585-7E87F615B1D6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9DE82421-3B3F-4B89-8585-7E87F615B1D6}.Release|x86.ActiveCfg = Release|Any CPU
 		{9DE82421-3B3F-4B89-8585-7E87F615B1D6}.Release|x86.Build.0 = Release|Any CPU
+		{5CF6FE83-5238-46F1-8102-FCC58BE19F79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5CF6FE83-5238-46F1-8102-FCC58BE19F79}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5CF6FE83-5238-46F1-8102-FCC58BE19F79}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5CF6FE83-5238-46F1-8102-FCC58BE19F79}.Debug|x86.Build.0 = Debug|Any CPU
+		{5CF6FE83-5238-46F1-8102-FCC58BE19F79}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5CF6FE83-5238-46F1-8102-FCC58BE19F79}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5CF6FE83-5238-46F1-8102-FCC58BE19F79}.Release|x86.ActiveCfg = Release|Any CPU
+		{5CF6FE83-5238-46F1-8102-FCC58BE19F79}.Release|x86.Build.0 = Release|Any CPU
+
+
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/RemoteUploadHost/ArchiveNow.conf
+++ b/src/RemoteUploadHost/ArchiveNow.conf
@@ -1,0 +1,5 @@
+{
+  "host": "localhost",
+  "port": 5000,
+  "directory": "/tmp"
+}

--- a/src/RemoteUploadHost/Program.cs
+++ b/src/RemoteUploadHost/Program.cs
@@ -1,0 +1,20 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace RemoteUploadHost
+{
+    internal class Program
+    {
+        private static async Task Main(string[] args)
+        {
+            var configPath = Path.Combine(AppContext.BaseDirectory, "ArchiveNow.conf");
+            var configuration = RemoteUploadConfig.Load(configPath);
+
+            var service = new RemoteUploadService(configuration);
+            await service.StartAsync();
+
+            await Task.Delay(-1);
+        }
+    }
+}

--- a/src/RemoteUploadHost/RemoteUploadConfig.cs
+++ b/src/RemoteUploadHost/RemoteUploadConfig.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace RemoteUploadHost
+{
+    public class RemoteUploadConfig
+    {
+        public string Host { get; set; } = string.Empty;
+        public int Port { get; set; }
+        public string Directory { get; set; } = string.Empty;
+
+        public static RemoteUploadConfig Load(string path)
+        {
+            if (!File.Exists(path))
+                throw new FileNotFoundException($"Configuration file '{path}' was not found.");
+
+            var json = File.ReadAllText(path);
+            var config = JsonSerializer.Deserialize<RemoteUploadConfig>(json) ?? new RemoteUploadConfig();
+            Validate(config);
+            return config;
+        }
+
+        private static void Validate(RemoteUploadConfig config)
+        {
+            if (string.IsNullOrWhiteSpace(config.Host))
+                throw new InvalidOperationException("Host is not configured.");
+
+            if (config.Port <= 0 || config.Port > 65535)
+                throw new InvalidOperationException("Port is invalid.");
+
+            if (string.IsNullOrWhiteSpace(config.Directory))
+                throw new InvalidOperationException("Directory is not configured.");
+
+            if (!System.IO.Directory.Exists(config.Directory))
+                throw new InvalidOperationException($"Directory '{config.Directory}' does not exist.");
+        }
+    }
+}

--- a/src/RemoteUploadHost/RemoteUploadHost.csproj
+++ b/src/RemoteUploadHost/RemoteUploadHost.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/RemoteUploadHost/RemoteUploadService.cs
+++ b/src/RemoteUploadHost/RemoteUploadService.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+
+namespace RemoteUploadHost
+{
+    public class RemoteUploadService
+    {
+        private readonly RemoteUploadConfig _config;
+
+        public RemoteUploadService(RemoteUploadConfig config)
+        {
+            _config = config;
+        }
+
+        public Task StartAsync()
+        {
+            // TODO: implement remote upload functionality
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add RemoteUploadHost project
- run RemoteUploadService and wait indefinitely
- validate host/port/directory settings from ArchiveNow.conf

## Testing
- `dotnet build src/RemoteUploadHost/RemoteUploadHost.csproj` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6890a078d9dc832197d802e557e875e5