### PR TITLE
feat: add RemoteUploadHost service installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,26 @@
 
 A configurable folder archiver supporting profiles. It allows the selection of the archiving algorithm provider, the destination (e.g., placing in the cloud like Google Drive), defining a blacklist of excluded files/folders, and additional actions (such as encryption, setting the output file name, etc.).
 
+## RemoteUploadHost service
+
+The `RemoteUploadHost` component can be installed as a Windows service to run in the background and handle remote uploads.
+
+### Installation
+
+Run the following PowerShell script to register the service and configure it to start automatically with Windows:
+
+```powershell
+./src/RemoteUploadHost/install-service.ps1
+```
+
+### Manual control
+
+You can manually manage the service using the `sc` utility:
+
+```cmd
+sc start ArchiveNowRemoteUploadHost
+sc stop ArchiveNowRemoteUploadHost
+```
+
+These commands allow you to start or stop the service without rebooting the system.
+

--- a/src/ArchiveNow.Integration/DefaultArchiveNowShellIntegrator.cs
+++ b/src/ArchiveNow.Integration/DefaultArchiveNowShellIntegrator.cs
@@ -1,5 +1,7 @@
 ﻿using SharpShell;
 using SharpShell.ServerRegistration;
+using System.Diagnostics;
+using System.IO;
 
 namespace ArchiveNow.Integration
 {
@@ -16,6 +18,23 @@ namespace ArchiveNow.Integration
 
             ServerRegistrationManager.InstallServer(_server, RegistrationType.OS64Bit, codeBase: true);
             ServerRegistrationManager.RegisterServer(_server, RegistrationType.OS64Bit);
+
+            var servicePath = Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "RemoteUploadHost.exe");
+            var createService = new ProcessStartInfo("sc.exe", $"create ArchiveNowRemoteUploadHost binPath= \"{servicePath}\" start= auto")
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            try
+            {
+                using var process = Process.Start(createService);
+                process?.WaitForExit();
+            }
+            catch
+            {
+                // ignore if service already exists or registration fails
+            }
         }
 
         public void Disintegrate()

--- a/src/RemoteUploadHost/install-service.ps1
+++ b/src/RemoteUploadHost/install-service.ps1
@@ -1,0 +1,11 @@
+param(
+    [string]$ServiceName = "ArchiveNowRemoteUploadHost",
+    [string]$ExecutablePath = (Join-Path $PSScriptRoot 'RemoteUploadHost.exe')
+)
+
+if (-not (Get-Service -Name $ServiceName -ErrorAction SilentlyContinue)) {
+    New-Service -Name $ServiceName -BinaryPathName "`"$ExecutablePath`"" -DisplayName "ArchiveNow Remote Upload Host" -StartupType Automatic | Out-Null
+    Write-Host "Service $ServiceName installed."
+} else {
+    Write-Host "Service $ServiceName already exists."
+}


### PR DESCRIPTION
## Summary
- ensure shell context menu installation creates a RemoteUploadHost service for autostart
- add PowerShell installer script for the RemoteUploadHost service
- document how to install and control the RemoteUploadHost service

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_6890a565de7c8321b14c5cb111a8e061