### PR TITLE
Rename SendToMailBox references to SendToMailbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A configurable folder archiver supporting profiles. It allows the selection of t
   
 ## Available After-Finished Actions
 
-- SendToMailBox
+- SendToMailbox
 - SendToArchiveNow
 - SendToGoogleDrive
 - SetClipboard

--- a/env/Profiles/Visual Studio Project (ReactJS).profile
+++ b/env/Profiles/Visual Studio Project (ReactJS).profile
@@ -24,7 +24,7 @@
 	"AfterFinishedActions":[  
 		
         {
-			"Name": "SendToMailBox",
+                        "Name": "SendToMailbox",
 			"Context": {
 				"Host": "smtp.gmail.com",
 				"Port": 587,

--- a/src/ArchiveNow.Actions.Core/ArchiveNow.Actions.Core.csproj
+++ b/src/ArchiveNow.Actions.Core/ArchiveNow.Actions.Core.csproj
@@ -69,7 +69,7 @@
     <Compile Include="Result\NullAfterFinishedActionResult.cs" />
     <Compile Include="RetryableAfterFinishedActionBase.cs" />
     <Compile Include="SendToArchiveNowAction.cs" />
-    <Compile Include="SendToMailBoxAction.cs" />
+    <Compile Include="SendToMailboxAction.cs" />
     <Compile Include="SetClipboardAction.cs" />
     <Compile Include="TestAction.cs" />
   </ItemGroup>

--- a/src/ArchiveNow.Actions.Core/SendToMailboxAction.cs
+++ b/src/ArchiveNow.Actions.Core/SendToMailboxAction.cs
@@ -8,7 +8,7 @@ using ArchiveNow.Utils;
 
 namespace ArchiveNow.Actions.Core
 {
-    public class SendToMailBoxAction : AfterFinishedActionBase
+    public class SendToMailboxAction : AfterFinishedActionBase
     {
         private const string DefaultSubject = "[ArchiveNow]";
         private const string DefaultBody = "The file was automatically sent by ArchiveNow!";
@@ -31,7 +31,7 @@ namespace ArchiveNow.Actions.Core
         /// Optional
         /// </summary>
         /// <param name="mailContext"></param>
-        public SendToMailBoxAction(MailContext mailContext)
+        public SendToMailboxAction(MailContext mailContext)
             : base(precedence: 8)
         {
             _host = mailContext.Host;

--- a/src/ArchiveNow.Configuration/AfterFinishedActionFactory.cs
+++ b/src/ArchiveNow.Configuration/AfterFinishedActionFactory.cs
@@ -16,7 +16,7 @@ namespace ArchiveNow.Configuration
 
             switch (name)
             {
-                case "SendToMailBox":
+                case "SendToMailbox":
                     var mailContext = new MailContext
                     {
                         Host = GetValue<string>(parameters, "Host"),
@@ -28,7 +28,7 @@ namespace ArchiveNow.Configuration
                         Subject = GetValue<string>(parameters, "Subject")
                     };
 
-                    creator = (() => new SendToMailBoxAction(mailContext));
+                    creator = (() => new SendToMailboxAction(mailContext));
                     break;
 
                 case "SendToGoogleDrive":


### PR DESCRIPTION
## Summary
- rename SendToMailBoxAction class and related references to SendToMailboxAction
- update project, factory, and docs to use SendToMailbox

## Testing
- `dotnet test src/ArchiveNow.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0366ea348321b70a0e3721be2eff