### PR TITLE
Track additional files for deletion

### DIFF
--- a/src/ArchiveNow.Actions.Core/AfterFinishedActionContext.cs
+++ b/src/ArchiveNow.Actions.Core/AfterFinishedActionContext.cs
@@ -1,12 +1,18 @@
-﻿namespace ArchiveNow.Actions.Core
+using System.Collections.Generic;
+
+namespace ArchiveNow.Actions.Core
 {
     public class AfterFinishedActionContext : IAfterFinishedActionContext
     {
         public string InputPath { get; }
 
-        public AfterFinishedActionContext(string inputPath)
+        public ICollection<string> AdditionalPaths { get; }
+
+        public AfterFinishedActionContext(string inputPath, ICollection<string> additionalPaths = null)
         {
             InputPath = inputPath;
+            AdditionalPaths = additionalPaths ?? new List<string>();
         }
     }
 }
+

--- a/src/ArchiveNow.Actions.Core/DeleteAction.cs
+++ b/src/ArchiveNow.Actions.Core/DeleteAction.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using ArchiveNow.Actions.Core.Result;
 using ArchiveNow.Utils;
@@ -23,6 +23,16 @@ namespace ArchiveNow.Actions.Core
                 if (File.Exists(context.InputPath))
                 {
                     File.Delete(context.InputPath);
+
+                    foreach (var path in context.AdditionalPaths)
+                    {
+                        if (File.Exists(path))
+                        {
+                            File.Delete(path);
+                        }
+                    }
+
+                    context.AdditionalPaths.Clear();
                 }
                 else
                 {
@@ -36,7 +46,8 @@ namespace ArchiveNow.Actions.Core
                 message = ex.Message;
             }
 
-            return new AfterFinishedActionResult(hasError.Not(), message);
+            return new AfterFinishedActionResult(hasError.Not(), context.InputPath, message);
         }
     }
 }
+

--- a/src/ArchiveNow.Actions.Core/EncryptAction.cs
+++ b/src/ArchiveNow.Actions.Core/EncryptAction.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using ArchiveNow.Actions.Core.Result;
 using ArchiveNow.Utils;
 using ArchiveNow.Utils.Security;
@@ -28,6 +28,7 @@ namespace ArchiveNow.Actions.Core
             try
             {
                 outputPath = _service.EncryptFile(context.InputPath, _publicKeyFilePath);
+                context.AdditionalPaths.Add(context.InputPath);
             }
             catch (Exception ex)
             {
@@ -39,3 +40,4 @@ namespace ArchiveNow.Actions.Core
         }
     }
 }
+

--- a/src/ArchiveNow.Actions.Core/IAfterFinishedActionContext.cs
+++ b/src/ArchiveNow.Actions.Core/IAfterFinishedActionContext.cs
@@ -1,7 +1,12 @@
-﻿namespace ArchiveNow.Actions.Core
+using System.Collections.Generic;
+
+namespace ArchiveNow.Actions.Core
 {
     public interface IAfterFinishedActionContext
     {
         string InputPath { get; }
+
+        ICollection<string> AdditionalPaths { get; }
     }
 }
+

--- a/src/ArchiveNow.Service/ArchiveNowService.cs
+++ b/src/ArchiveNow.Service/ArchiveNowService.cs
@@ -187,12 +187,14 @@ namespace ArchiveNow.Service
                     var progress = new Progress<AfterFinishedActionProgress>();
                     progress.ProgressChanged += ProgressOnProgressChanged;
 
+                    var additionalPaths = new List<string>();
+
                     foreach (var action in actions)
                     {
                         OnActionExecuting(action);
 
                         action.Progress = progress;
-                        var actionResult = action.Execute(new AfterFinishedActionContext(inputPath));
+                        var actionResult = action.Execute(new AfterFinishedActionContext(inputPath, additionalPaths));
 
                         OnActionExecuted(action, actionResult);
 


### PR DESCRIPTION
## Summary
- extend action context to keep additional file paths
- record original path during encryption
- delete both encrypted and original files

## Testing
- `dotnet test src/ArchiveNow.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1bb5474083219a46f55c53ca23cf