### PR TITLE
Expose configurable app version in Help output

### DIFF
--- a/env/ArchiveNow.conf
+++ b/env/ArchiveNow.conf
@@ -1,5 +1,6 @@
 {
-	"DefaultProfile": "Test",
-	"ShowSummary" : true,
-	"ArchiveProviderName" : "SharpZip"
-}
+        "Version": "1.0.0",
+        "DefaultProfile": "Test",
+        "ShowSummary" : true,
+        "ArchiveProviderName" : "SharpZip"
+ }

--- a/src/ArchiveNow.Configuration/ArchiveNowConfiguration.cs
+++ b/src/ArchiveNow.Configuration/ArchiveNowConfiguration.cs
@@ -22,6 +22,8 @@ namespace ArchiveNow.Configuration
 
         public bool ShowSummary { get; set; }
 
+        public string Version { get; set; }
+
         public bool HasDefaultProfile => !DefaultProfile.IsEmpty;
 
         public RemoteUploadHostConfiguration RemoteUploadHost { get; set; } = new RemoteUploadHostConfiguration();
@@ -29,7 +31,7 @@ namespace ArchiveNow.Configuration
         public override string ToString()
         {
             var builder = new StringBuilder();
-            builder.AppendLine($"ShowSummary: {ShowSummary}\nDefaultProfile: {DefaultProfile}");
+            builder.AppendLine($"ShowSummary: {ShowSummary}\nDefaultProfile: {DefaultProfile}\nVersion: {Version}");
             builder.AppendLine("Maps:");
 
             foreach (var item in DirectoryProfileMap)

--- a/src/ArchiveNow.Configuration/IArchiveNowConfiguration.cs
+++ b/src/ArchiveNow.Configuration/IArchiveNowConfiguration.cs
@@ -13,5 +13,7 @@ namespace ArchiveNow.Configuration
         bool HasDefaultProfile { get; }
 
         bool ShowSummary { get; set; }
+
+        string Version { get; set; }
     }
 }

--- a/src/ArchiveNow/App.xaml.cs
+++ b/src/ArchiveNow/App.xaml.cs
@@ -219,7 +219,22 @@ namespace ArchiveNow
             parser.SetupHelp("?", "help")
                 .Callback(helpText =>
                     {
-                        var message = $"Invalid or missing argument!\n\nExpected options:\n{helpText}";
+                        string version = string.Empty;
+                        try
+                        {
+                            if (File.Exists(_configFilePath))
+                            {
+                                var configurationProvider = new ArchiveNowConfigurationProvider(_configFilePath, _profileRepository);
+                                version = configurationProvider.Read().Version;
+                            }
+                        }
+                        catch
+                        {
+                            // ignore configuration errors when showing help
+                        }
+
+                        var versionInfo = string.IsNullOrWhiteSpace(version) ? string.Empty : $"Version: {version}\n\n";
+                        var message = $"{versionInfo}Invalid or missing argument!\n\nExpected options:\n{helpText}";
 
                         MessageBox.Show(message, ClientName, MessageBoxButton.OK, MessageBoxImage.Error);
                     }

--- a/src/ArchiveNow/ArchiveNow.conf
+++ b/src/ArchiveNow/ArchiveNow.conf
@@ -1,10 +1,11 @@
 ﻿{
-	"DirectoryProfileMap": {
-  	},
-	"DefaultProfileName": "Test",
-	"ShowSummary" : true,
-	"RemoteUploadServer": {
-		"Port": 5000,
-		"UploadsDirectory": "uploads"
-	}
+        "Version": "1.0.0",
+        "DirectoryProfileMap": {
+        },
+        "DefaultProfileName": "Test",
+        "ShowSummary" : true,
+        "RemoteUploadServer": {
+                "Port": 5000,
+                "UploadsDirectory": "uploads"
+        }
 }


### PR DESCRIPTION
## Summary
- add `Version` field to configuration models and JSON
- show application version in Help dialog

## Testing
- `dotnet test src/ArchiveNow.sln` *(fails: command not found)*
- `sudo apt-get update` *(fails: 403 error)*

------
https://chatgpt.com/codex/tasks/task_e_68ae23b9c52083218673bb7793e66a69